### PR TITLE
Full URL support

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@ var makeTable = require('./makeTable.js')
 var fs = require('fs')
 
 var KEY = process.argv[2]
+if (KEY.toLowerCase().indexOf("key=") > 0 ) {
+  var re = /key=([a-zA-Z0-9+]+)/;
+  var VAL = KEY.match(re);
+  KEY = VAL;
+}
+
 var save = false
 
 if (process.argv[3] && process.argv[3].match("--save")) {


### PR DESCRIPTION
Made the script also accept a full Google Docs/Drive item URL as a parameter instead of only the key. The key is automatically extracted from the full URL. The older method of only giving the key as a parameter also works.
